### PR TITLE
Custom icon-set

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,13 @@
   ],
   "dependencies": {
     "polymer": "Polymer/polymer#^1.1.0",
-    "iron-a11y-keys": "PolymerElements/iron-a11y-keys#~1.0.4"
+    "iron-a11y-keys": "PolymerElements/iron-a11y-keys#^1.0.4",
+    "iron-iconset-svg": "PolymerElements/iron-iconset-svg#^1.0.0",
+    "iron-behaviors": "PolymerElements/iron-behaviors#^1.0.0",
+    "iron-icon": "PolymerElements/iron-icon#^1.0.0",
+    "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
+    "paper-material": "PolymerElements/paper-material#^1.0.0",
+    "paper-styles": "PolymerElements/paper-styles#^1.0.0"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",

--- a/bower.json
+++ b/bower.json
@@ -22,9 +22,10 @@
   "dependencies": {
     "polymer": "Polymer/polymer#^1.1.0",
     "iron-a11y-keys": "PolymerElements/iron-a11y-keys#^1.0.4",
-    "iron-iconset-svg": "PolymerElements/iron-iconset-svg#^1.0.0",
     "iron-behaviors": "PolymerElements/iron-behaviors#^1.0.0",
     "iron-icon": "PolymerElements/iron-icon#^1.0.0",
+    "iron-iconset-svg": "PolymerElements/iron-iconset-svg#^1.0.0",
+    "iron-behaviors": "PolymerElements/iron-behaviors#^1.0.0",
     "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
     "paper-material": "PolymerElements/paper-material#^1.0.0",
     "paper-styles": "PolymerElements/paper-styles#^1.0.0"

--- a/paper-chip-icons.html
+++ b/paper-chip-icons.html
@@ -1,0 +1,10 @@
+<link rel="import" href="../bower_components/iron-icon/iron-icon.html">
+<link rel="import" href="../bower_components/iron-iconset-svg/iron-iconset-svg.html">
+
+<iron-iconset-svg size="24" name="paper-chip">
+	<svg>
+		<defs>
+			<g id="close"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path></g>
+		</defs>
+	</svg>
+</iron-iconset-svg>

--- a/paper-chip-icons.html
+++ b/paper-chip-icons.html
@@ -1,5 +1,5 @@
-<link rel="import" href="../bower_components/iron-icon/iron-icon.html">
-<link rel="import" href="../bower_components/iron-iconset-svg/iron-iconset-svg.html">
+<link rel="import" href="../iron-icon/iron-icon.html">
+<link rel="import" href="../iron-iconset-svg/iron-iconset-svg.html">
 
 <iron-iconset-svg size="24" name="paper-chip">
 	<svg>

--- a/paper-chip.html
+++ b/paper-chip.html
@@ -1,12 +1,12 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-a11y-keys/iron-a11y-keys.html">
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
-<link rel="import" href="../iron-icons/iron-icons.html">
 <link rel="import" href="../iron-icon/iron-icon.html">
 <link rel="import" href="../paper-material/paper-material.html">
 <link rel="import" href="../paper-styles/paper-styles.html">
 
 <link rel="import" href="paper-chip-behavior.html">
+<link rel="import" href="paper-chip-icons.html">
 <!--
 Material Design: [Chips](http://www.google.com/design/spec/components/chips.html)
 
@@ -168,7 +168,7 @@ Basic chip with single letter instead of an icon
           </div>
           <div class="remove-btn-container">
             <div class="remove-btn" on-tap="remove" aria-label="remove button">
-              <iron-icon icon="close"></iron-icon>
+              <iron-icon icon="paper-chip:close"></iron-icon>
             </div>
           </div>
         </div>


### PR DESCRIPTION
The full iron-icons dependency was used, however only one icon was actually used in this element. To increase performance and save bandwidth, it's recommended to use a custom icon-set in production environments. This pull request provides a custom icon-set and fixes the list of dependencies in the bower.json.
