### PR TITLE
Replacing paper-styles import with only the color-import

### DIFF
--- a/paper-chip.html
+++ b/paper-chip.html
@@ -4,7 +4,7 @@
 <link rel="import" href="../iron-icons/iron-icons.html">
 <link rel="import" href="../iron-icon/iron-icon.html">
 <link rel="import" href="../paper-material/paper-material.html">
-<link rel="import" href="../paper-styles/paper-styles.html">
+<link rel="import" href="../paper-styles/color.html">
 
 <link rel="import" href="paper-chip-behavior.html">
 <!--


### PR DESCRIPTION
Because the paper-styles import is causing warnings (see: PolymerElements/paper-styles#105) I purpose to replace it with importing color.html. The other paper-styles are not used in this element, so there is no need to import them.
